### PR TITLE
chore: add missing peerDependencies in `@web3auth/modal`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4982,7 +4982,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
       "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
-      "dev": true,
       "dependencies": {
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha512": "^1.0.1",
@@ -5059,7 +5058,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
       "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
-      "dev": true,
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -6685,7 +6683,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.0.tgz",
       "integrity": "sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==",
-      "dev": true,
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -6710,7 +6707,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
       "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
-      "dev": true,
       "dependencies": {
         "tslib": "1.14.1"
       }
@@ -6718,8 +6714,7 @@
     "node_modules/@walletconnect/environment/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/events": {
       "version": "1.0.1",
@@ -6754,7 +6749,6 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
       "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
-      "dev": true,
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -6764,8 +6758,7 @@
     "node_modules/@walletconnect/jsonrpc-provider/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
@@ -6785,7 +6778,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
       "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
-      "dev": true,
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.3",
@@ -6795,14 +6787,12 @@
     "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
       "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
-      "dev": true,
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -6860,7 +6850,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
       "integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
-      "dev": true,
       "dependencies": {
         "@stablelib/ed25519": "^1.0.2",
         "@stablelib/random": "^1.0.1",
@@ -6873,8 +6862,7 @@
     "node_modules/@walletconnect/relay-auth/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
@@ -6893,7 +6881,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.0.tgz",
       "integrity": "sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==",
-      "dev": true,
       "dependencies": {
         "@walletconnect/core": "2.11.0",
         "@walletconnect/events": "^1.0.1",
@@ -15843,7 +15830,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
       "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
-      "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -19588,7 +19574,6 @@
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -28467,8 +28452,7 @@
     "node_modules/unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "dev": true
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -30368,7 +30352,12 @@
       },
       "peerDependencies": {
         "@babel/runtime": "7.x",
-        "@solana/web3.js": "^1.x"
+        "@solana/web3.js": "^1.x",
+        "@walletconnect/sign-client": "^2.x",
+        "@walletconnect/types": "^2.x",
+        "@walletconnect/utils": "^2.x",
+        "react": "^18.x",
+        "react-dom": "^18.x"
       }
     },
     "packages/no-modal": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -50,7 +50,12 @@
   "name": "@web3auth/modal",
   "peerDependencies": {
     "@babel/runtime": "7.x",
-    "@solana/web3.js": "^1.x"
+    "@solana/web3.js": "^1.x",
+    "@walletconnect/sign-client": "^2.x",
+    "@walletconnect/types": "^2.x",
+    "@walletconnect/utils": "^2.x",
+    "react": "^18.x",
+    "react-dom": "^18.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## **Description**

This PR adds missing peer dependencies to the `@web3auth/modal` packages. Currently, `@web3auth/modal` has the responsibility of handling the following peer dependencies:

* Inherited from `@web3auth/wallet-connect-v2-adapter`
  * `@walletconnect/sign-client` `^2.x`
  * `@walletconnect/types` `^2.x`
  * `@walletconnect/utils` `^2.x`
* Inherited from `@web3auth/ui`
  * `react` `^18.x`
  * `react-dom` `^18.x`

However, it doesn't handle them properly: it does neither provide them in `dependencies` or pass them to the dependants in `peerDependencies`. This causes the following warnings in Yarn v3:

```
➤ YN0002: │ @web3auth/modal@npm:7.3.1 [3770b] doesn't provide @walletconnect/sign-client (p4a307), requested by @web3auth/wallet-connect-v2-adapter
➤ YN0002: │ @web3auth/modal@npm:7.3.1 [3770b] doesn't provide @walletconnect/types (p55b86), requested by @web3auth/wallet-connect-v2-adapter
➤ YN0002: │ @web3auth/modal@npm:7.3.1 [3770b] doesn't provide @walletconnect/utils (p017c0), requested by @web3auth/wallet-connect-v2-adapter
➤ YN0002: │ @web3auth/modal@npm:7.3.1 [3770b] doesn't provide react (p4bd35), requested by @web3auth/ui
➤ YN0002: │ @web3auth/modal@npm:7.3.1 [3770b] doesn't provide react-dom (p9f143), requested by @web3auth/ui
```

The solution is simply to list the dependencies as `peerDependencies` of `@web3auth/modal`. Thus, the responsibility of installing them is passed to the users instead of remaining unhanded.

## **Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update